### PR TITLE
Increase contrast on main page

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,12 +14,12 @@ h6 {
 }
 
 a {
-    color: #55f;
+    color: #aaf;
     text-decoration: none;
 }
 
 a::visited {
-    color: #55f;
+    color: #aa7;
 }
 
 .inline {


### PR DESCRIPTION
Currently the main page's links are #55f, which comes out to 85,85,225 on the page, which looks like this:
![image](https://user-images.githubusercontent.com/42079760/108653025-64941780-74bd-11eb-9c3f-60f8592e9213.png)
The contrast here is amazingly terrible.

I propose changing the link color to #aaf:
![image](https://user-images.githubusercontent.com/42079760/108653061-75448d80-74bd-11eb-821d-d87297e5c8b7.png)
and keeping with the site's accent theme, the visited link color to #aa7:
![image](https://user-images.githubusercontent.com/42079760/108653096-868d9a00-74bd-11eb-954c-11331079627d.png)
